### PR TITLE
Fix sed compatibility and update dotfile configurations

### DIFF
--- a/chezmoi/.chezmoiignore
+++ b/chezmoi/.chezmoiignore
@@ -28,7 +28,7 @@ README.md
 !.claude/commands/custom-code-review.md
 !.claude/plugins
 .claude/plugins/*
-!.claude/plugins/blocklist.json
+!.claude/plugins/private_blocklist.json
 !.claude/plugins/installed_plugins.json
 !.claude/plugins/known_marketplaces.json
 !.claude/skills
@@ -166,6 +166,7 @@ README.md
 !.local/bin/transfer_pocket_to_reeder.py
 !.local/bin/typora
 !.local/bin/uncommitted-francis
+!.local/bin/update-lychee-rev
 !.local/bin/update-requirements
 !.local/bin/youtube-dl-francis
 .local/pipx/

--- a/chezmoi/dot_local/bin/executable_update-lychee-rev
+++ b/chezmoi/dot_local/bin/executable_update-lychee-rev
@@ -24,5 +24,9 @@ if ! grep -q 'rev: nightly' "$CONFIG"; then
     exit 0
 fi
 
-sed -i '' "s/rev: nightly/rev: $latest/" "$CONFIG"
+if [[ "$(uname)" == "Darwin" ]]; then
+    sed -i '' "s/rev: nightly/rev: $latest/" "$CONFIG"
+else
+    sed -i "s/rev: nightly/rev: $latest/" "$CONFIG"
+fi
 echo "Updated $CONFIG: rev: nightly -> rev: $latest"

--- a/chezmoi/dot_local/bin/executable_update-lychee-rev
+++ b/chezmoi/dot_local/bin/executable_update-lychee-rev
@@ -4,13 +4,13 @@ set -euo pipefail
 REPO="https://github.com/lycheeverse/lychee.git"
 CONFIG=".pre-commit-config.yaml"
 
-latest=$(git ls-remote --tags "$REPO" \
-    | grep -v '\^{}' \
-    | awk '{print $2}' \
-    | sed 's|refs/tags/||' \
-    | grep '^v[0-9]' \
-    | sort -V \
-    | tail -1)
+latest=$(git ls-remote --tags "$REPO" |
+    grep -v '\^{}' |
+    awk '{print $2}' |
+    sed 's|refs/tags/||' |
+    grep '^v[0-9]' |
+    sort -V |
+    tail -1)
 
 if [[ -z "$latest" ]]; then
     echo "error: could not determine latest lychee version" >&2

--- a/tests/bats/copyright-year.bats
+++ b/tests/bats/copyright-year.bats
@@ -18,6 +18,7 @@ setup() {
     git init
     git config user.email "test@example.com"
     git config user.name "Test User"
+    git config commit.gpgsign false
     # Create HEAD so git diff-index has something to diff against.
     git commit --allow-empty -m "initial commit"
 }

--- a/tests/bats/update-lychee-rev.bats
+++ b/tests/bats/update-lychee-rev.bats
@@ -67,10 +67,10 @@ _typical_tags() {
     _stub_git "$(_typical_tags)"
     cat >.pre-commit-config.yaml <<'EOF'
 repos:
-  - repo: https://github.com/lycheeverse/lychee
-    rev: nightly
-    hooks:
-      - id: lychee
+    - repo: https://github.com/lycheeverse/lychee
+      rev: nightly
+      hooks:
+          - id: lychee
 EOF
     run bash "${SCRIPT}"
     [ "$status" -eq 0 ]
@@ -95,10 +95,10 @@ EOF
     _stub_git "$(_typical_tags)"
     cat >.pre-commit-config.yaml <<'EOF'
 repos:
-  - repo: https://github.com/lycheeverse/lychee
-    rev: v0.14.0
-    hooks:
-      - id: lychee
+    - repo: https://github.com/lycheeverse/lychee
+      rev: v0.14.0
+      hooks:
+          - id: lychee
 EOF
     run bash "${SCRIPT}"
     [ "$status" -eq 0 ]

--- a/tests/bats/update-lychee-rev.bats
+++ b/tests/bats/update-lychee-rev.bats
@@ -65,13 +65,7 @@ _typical_tags() {
 
 @test "replaces 'rev: nightly' with the latest tag and exits 0" {
     _stub_git "$(_typical_tags)"
-    cat >.pre-commit-config.yaml <<'EOF'
-repos:
-    - repo: https://github.com/lycheeverse/lychee
-      rev: nightly
-      hooks:
-          - id: lychee
-EOF
+    printf 'rev: nightly\n' >.pre-commit-config.yaml
     run bash "${SCRIPT}"
     [ "$status" -eq 0 ]
     grep -q 'rev: v0.14.0' .pre-commit-config.yaml
@@ -93,13 +87,7 @@ EOF
 
 @test "exits 0 with 'nothing to update' when config lacks rev: nightly" {
     _stub_git "$(_typical_tags)"
-    cat >.pre-commit-config.yaml <<'EOF'
-repos:
-    - repo: https://github.com/lycheeverse/lychee
-      rev: v0.14.0
-      hooks:
-          - id: lychee
-EOF
+    printf 'rev: v0.14.0\n' >.pre-commit-config.yaml
     run bash "${SCRIPT}"
     [ "$status" -eq 0 ]
     [[ "$output" == *"nothing to update"* ]]


### PR DESCRIPTION
## Summary
This PR addresses cross-platform compatibility issues and updates dotfile configurations to improve script reliability and maintainability.

## Key Changes
- **sed command compatibility**: Modified `update-lychee-rev` script to handle platform differences between macOS (BSD sed) and Linux (GNU sed). macOS requires the `-i ''` syntax while Linux uses `-i` without an argument.
- **Dotfile tracking**: Added `update-lychee-rev` to the chezmoi ignore list to ensure it's properly tracked and deployed.
- **Claude plugin configuration**: Renamed tracked plugin file from `blocklist.json` to `private_blocklist.json` to better reflect its purpose.
- **Test reliability**: Disabled GPG signing in git test configuration to prevent test failures in environments without GPG setup.

## Implementation Details
The sed fix uses `uname` to detect the operating system at runtime and applies the appropriate sed syntax, ensuring the script works correctly on both macOS and Linux systems without requiring separate versions.

https://claude.ai/code/session_01LNTjYKz5HnwaKFKMYgpeuS