### PR TITLE
Fix bats test failures and macOS compatibility

### DIFF
--- a/bin/get-age-key
+++ b/bin/get-age-key
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
-set -o errexit                # Exit on error. Append || true if you expect an error.
-set -o errtrace               # Exit on error inside any functions or subshells.
-set -o noclobber              # Don't allow overwriting files.
-set -o nounset                # Don't allow use of undefined vars. Use ${VAR:-} to use an undefined VAR.
-set -o pipefail               # Produce a failure return code if any pipeline command errors.
-shopt -s failglob             # Cause globs that don't get expanded to cause errors.
-shopt -s globstar 2>/dev/null # Match all files and zero or more sub-directories.
+set -o errexit                        # Exit on error. Append || true if you expect an error.
+set -o errtrace                       # Exit on error inside any functions or subshells.
+set -o noclobber                      # Don't allow overwriting files.
+set -o nounset                        # Don't allow use of undefined vars. Use ${VAR:-} to use an undefined VAR.
+set -o pipefail                       # Produce a failure return code if any pipeline command errors.
+shopt -s failglob                     # Cause globs that don't get expanded to cause errors.
+shopt -s globstar 2>/dev/null || true # Match all files and zero or more sub-directories.
 
 # Get age key from 1password and save it to disk.
 # Requires 1password CLI to be installed and signed in.

--- a/bin/get-brew-diffs
+++ b/bin/get-brew-diffs
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
-set -o errexit                # Exit on error. Append || true if you expect an error.
-set -o errtrace               # Exit on error inside any functions or subshells.
-set -o noclobber              # Don't allow overwriting files.
-set -o nounset                # Don't allow use of undefined vars. Use ${VAR:-} to use an undefined VAR.
-set -o pipefail               # Produce a failure return code if any pipeline command errors.
-shopt -s failglob             # Cause globs that don't get expanded to cause errors.
-shopt -s globstar 2>/dev/null # Match all files and zero or more sub-directories.
+set -o errexit                        # Exit on error. Append || true if you expect an error.
+set -o errtrace                       # Exit on error inside any functions or subshells.
+set -o noclobber                      # Don't allow overwriting files.
+set -o nounset                        # Don't allow use of undefined vars. Use ${VAR:-} to use an undefined VAR.
+set -o pipefail                       # Produce a failure return code if any pipeline command errors.
+shopt -s failglob                     # Cause globs that don't get expanded to cause errors.
+shopt -s globstar 2>/dev/null || true # Match all files and zero or more sub-directories.
 
 tmpfile="$(mktemp)"
 

--- a/bin/mega-linter-cmd
+++ b/bin/mega-linter-cmd
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
-set -o errexit                # Exit on error. Append || true if you expect an error.
-set -o errtrace               # Exit on error inside any functions or subshells.
-set -o noclobber              # Don't allow overwriting files.
-set -o nounset                # Don't allow use of undefined vars. Use ${VAR:-} to use an undefined VAR.
-set -o pipefail               # Produce a failure return code if any pipeline command errors.
-shopt -s failglob             # Cause globs that don't get expanded to cause errors.
-shopt -s globstar 2>/dev/null # Match all files and zero or more sub-directories.
+set -o errexit                        # Exit on error. Append || true if you expect an error.
+set -o errtrace                       # Exit on error inside any functions or subshells.
+set -o noclobber                      # Don't allow overwriting files.
+set -o nounset                        # Don't allow use of undefined vars. Use ${VAR:-} to use an undefined VAR.
+set -o pipefail                       # Produce a failure return code if any pipeline command errors.
+shopt -s failglob                     # Cause globs that don't get expanded to cause errors.
+shopt -s globstar 2>/dev/null || true # Match all files and zero or more sub-directories.
 
 # editorconfig-checker-disable-next-line
 npx mega-linter-runner --env "'ENABLE_LINTERS=PYTHON_BLACK,PYTHON_ISORT,PYTHON_BANDIT,PYTHON_PYRIGHT,ACTION_ACTIONLINT,BASH_SHELLCHECK,BASH_SHFMT,COPYPASTE_JSCPD,EDITORCONFIG_EDITORCONFIG_CHECKER,JSON_JSONLINT,JSON_V8R,JSON_PRETTIER,MARKDOWN_MARKDOWN_TABLE_FORMATTER,REPOSITORY_DUSTILOCK,REPOSITORY_GIT_DIFF,REPOSITORY_GRYPE,REPOSITORY_KICS,REPOSITORY_SECRETLINT,REPOSITORY_SYFT,REPOSITORY_TRIVY,REPOSITORY_TRIVY_SBOM,REPOSITORY_TRUFFLEHOG,YAML_PRETTIER,YAML_YAMLLINT,YAML_V8R'" \

--- a/bin/op
+++ b/bin/op
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 
-set -o errexit                # Exit on error. Append || true if you expect an error.
-set -o errtrace               # Exit on error inside any functions or subshells.
-set -o noclobber              # Don't allow overwriting files.
-set -o nounset                # Don't allow use of undefined vars. Use ${VAR:-} to use an undefined VAR.
-set -o pipefail               # Produce a failure return code if any pipeline command errors.
-shopt -s failglob             # Cause globs that don't get expanded to cause errors.
-shopt -s globstar 2>/dev/null # Match all files and zero or more sub-directories.
+set -o errexit                        # Exit on error. Append || true if you expect an error.
+set -o errtrace                       # Exit on error inside any functions or subshells.
+set -o noclobber                      # Don't allow overwriting files.
+set -o nounset                        # Don't allow use of undefined vars. Use ${VAR:-} to use an undefined VAR.
+set -o pipefail                       # Produce a failure return code if any pipeline command errors.
+shopt -s failglob                     # Cause globs that don't get expanded to cause errors.
+shopt -s globstar 2>/dev/null || true # Match all files and zero or more sub-directories.
 
 echo "default-value"

--- a/chezmoi/dot_local/bin/executable_check-freespace
+++ b/chezmoi/dot_local/bin/executable_check-freespace
@@ -26,20 +26,21 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-set -o errexit                # Exit on error. Append || true if you expect an error.
-set -o errtrace               # Exit on error inside any functions or subshells.
-set -o noclobber              # Don't allow overwriting files.
-set -o nounset                # Don't allow use of undefined vars. Use ${VAR:-} to use an undefined VAR.
-set -o pipefail               # Produce a failure return code if any pipeline command errors.
-shopt -s failglob             # Cause globs that don't get expanded to cause errors.
-shopt -s globstar 2>/dev/null # Match all files and zero or more sub-directories.
+set -o errexit                        # Exit on error. Append || true if you expect an error.
+set -o errtrace                       # Exit on error inside any functions or subshells.
+set -o noclobber                      # Don't allow overwriting files.
+set -o nounset                        # Don't allow use of undefined vars. Use ${VAR:-} to use an undefined VAR.
+set -o pipefail                       # Produce a failure return code if any pipeline command errors.
+shopt -s failglob                     # Cause globs that don't get expanded to cause errors.
+shopt -s globstar 2>/dev/null || true # Match all files and zero or more sub-directories.
 
 function run_test {
     # shellcheck disable=SC2312
-    df . -k | tail -n 1 | awk ' {
-    if ($4 < (1024 * 100))
-        print "Warning: less then 100MB of free space left." > "/dev/stderr"
-    }'
+    local available
+    available=$(df -k . | tail -n 1 | awk '{print $4}')
+    if ((available < 1024 * 100)); then
+        echo "Warning: less then 100MB of free space left." >&2
+    fi
 }
 
 case "${1:-}" in

--- a/chezmoi/dot_local/bin/executable_copyright-year
+++ b/chezmoi/dot_local/bin/executable_copyright-year
@@ -27,13 +27,13 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-set -o errexit                # Exit on error. Append || true if you expect an error.
-set -o errtrace               # Exit on error inside any functions or subshells.
-set -o noclobber              # Don't allow overwriting files.
-set -o nounset                # Don't allow use of undefined vars. Use ${VAR:-} to use an undefined VAR.
-set -o pipefail               # Produce a failure return code if any pipeline command errors.
-shopt -s failglob             # Cause globs that don't get expanded to cause errors.
-shopt -s globstar 2>/dev/null # Match all files and zero or more sub-directories.
+set -o errexit                        # Exit on error. Append || true if you expect an error.
+set -o errtrace                       # Exit on error inside any functions or subshells.
+set -o noclobber                      # Don't allow overwriting files.
+set -o nounset                        # Don't allow use of undefined vars. Use ${VAR:-} to use an undefined VAR.
+set -o pipefail                       # Produce a failure return code if any pipeline command errors.
+shopt -s failglob                     # Cause globs that don't get expanded to cause errors.
+shopt -s globstar 2>/dev/null || true # Match all files and zero or more sub-directories.
 
 function test_file {
     file="${1}"

--- a/chezmoi/dot_local/bin/executable_freespace
+++ b/chezmoi/dot_local/bin/executable_freespace
@@ -27,20 +27,21 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 
-set -o errexit                # Exit on error. Append || true if you expect an error.
-set -o errtrace               # Exit on error inside any functions or subshells.
-set -o noclobber              # Don't allow overwriting files.
-set -o nounset                # Don't allow use of undefined vars. Use ${VAR:-} to use an undefined VAR.
-set -o pipefail               # Produce a failure return code if any pipeline command errors.
-shopt -s failglob             # Cause globs that don't get expanded to cause errors.
-shopt -s globstar 2>/dev/null # Match all files and zero or more sub-directories.
+set -o errexit                        # Exit on error. Append || true if you expect an error.
+set -o errtrace                       # Exit on error inside any functions or subshells.
+set -o noclobber                      # Don't allow overwriting files.
+set -o nounset                        # Don't allow use of undefined vars. Use ${VAR:-} to use an undefined VAR.
+set -o pipefail                       # Produce a failure return code if any pipeline command errors.
+shopt -s failglob                     # Cause globs that don't get expanded to cause errors.
+shopt -s globstar 2>/dev/null || true # Match all files and zero or more sub-directories.
 
 function run_test {
     # shellcheck disable=SC2312
-    df . -k | tail -n 1 | awk ' {
-    if ($4 < (1024 * 100))
-        print "Warning: less then 100MB of free space left." > "/dev/stderr"
-    }'
+    local available
+    available=$(df -k . | tail -n 1 | awk '{print $4}')
+    if ((available < 1024 * 100)); then
+        echo "Warning: less then 100MB of free space left." >&2
+    fi
 }
 
 case "${1:-}" in


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Add `|| true` to `shopt -s globstar 2>/dev/null` in all scripts so a non-zero exit from older/unsupported bash versions doesn't abort under `set -o errexit`
- Change `df . -k` → `df -k .` for BSD df (macOS) argument order compatibility
- Replace `awk print > "/dev/stderr"` with bash arithmetic + `echo >&2` in check-freespace/freespace for portable stderr output
- Disable git commit signing in `copyright-year.bats` setup to prevent failures in environments with `commit.gpgsign=true` globally configured
- Make `sed` in `update-lychee-rev` cross-platform (BSD vs GNU)
- Fix shfmt formatting and editorconfig indentation in test files
- Fix `.chezmoiignore`: correct `blocklist.json` → `private_blocklist.json`, add missing `!.local/bin/update-lychee-rev`

## Test plan

- [ ] All 54 bats tests pass locally (`bats tests/bats/`)
- [ ] pre-commit.ci passes (shfmt, editorconfig-checker)
- [ ] `Test Chezmoi Dotfiles` workflow passes on macOS

https://claude.ai/code/session_01LNTjYKz5HnwaKFKMYgpeuS
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LNTjYKz5HnwaKFKMYgpeuS)_