### PR TITLE
Fix shellcheck issues in bats test files

### DIFF
--- a/tests/bats/copyright-year.bats
+++ b/tests/bats/copyright-year.bats
@@ -9,6 +9,7 @@
 # Strategy: each test spins up a temporary git repository so the script
 # can run against real staged files without touching the main repo.
 
+# shellcheck disable=SC2154  # BATS_TEST_DIRNAME is set by the BATS runner
 SCRIPT="${BATS_TEST_DIRNAME}/../../chezmoi/dot_local/bin/executable_copyright-year"
 YEAR=$(date +%Y)
 
@@ -34,8 +35,8 @@ teardown() {
 
 @test "--about prints a description and exits 0" {
     run bash "${SCRIPT}" --about
-    [ "$status" -eq 0 ]
-    [[ "$output" == *"copyright"* ]]
+    [[ "${status}" -eq 0 ]]
+    [[ "${output}" == *"copyright"* ]]
 }
 
 # ---------------------------------------------------------------------------
@@ -46,7 +47,7 @@ teardown() {
     echo "Just some code, no copyright here." >no-copyright.txt
     git add no-copyright.txt
     run bash "${SCRIPT}"
-    [ "$status" -eq 0 ]
+    [[ "${status}" -eq 0 ]]
 }
 
 # ---------------------------------------------------------------------------
@@ -57,14 +58,14 @@ teardown() {
     echo "# Copyright ${YEAR} Someone" >valid.txt
     git add valid.txt
     run bash "${SCRIPT}"
-    [ "$status" -eq 0 ]
+    [[ "${status}" -eq 0 ]]
 }
 
 @test "file with multi-year copyright range including current year: exits 0" {
     echo "# Copyright 2019-${YEAR} Someone" >range.txt
     git add range.txt
     run bash "${SCRIPT}"
-    [ "$status" -eq 0 ]
+    [[ "${status}" -eq 0 ]]
 }
 
 # ---------------------------------------------------------------------------
@@ -75,8 +76,8 @@ teardown() {
     echo "# Copyright 2020 Someone" >outdated.txt
     git add outdated.txt
     run bash "${SCRIPT}"
-    [ "$status" -ne 0 ]
-    [[ "$output" == *"Error"* ]]
+    [[ "${status}" -ne 0 ]]
+    [[ "${output}" == *"Error"* ]]
 }
 
 # ---------------------------------------------------------------------------
@@ -88,7 +89,7 @@ teardown() {
     echo "# Copyright ${YEAR} Alice" >valid-holder.txt
     git add valid-holder.txt
     run bash "${SCRIPT}"
-    [ "$status" -eq 0 ]
+    [[ "${status}" -eq 0 ]]
 }
 
 @test "copyright has current year but omits holder with configured holder: exits non-zero" {
@@ -96,8 +97,8 @@ teardown() {
     echo "# Copyright ${YEAR}" >missing-holder.txt
     git add missing-holder.txt
     run bash "${SCRIPT}"
-    [ "$status" -ne 0 ]
-    [[ "$output" == *"Error"* ]]
+    [[ "${status}" -ne 0 ]]
+    [[ "${output}" == *"Error"* ]]
 }
 
 @test "copyright has current year but wrong holder: exits non-zero" {
@@ -105,8 +106,8 @@ teardown() {
     echo "# Copyright ${YEAR} Bob" >wrong-holder.txt
     git add wrong-holder.txt
     run bash "${SCRIPT}"
-    [ "$status" -ne 0 ]
-    [[ "$output" == *"Error"* ]]
+    [[ "${status}" -ne 0 ]]
+    [[ "${output}" == *"Error"* ]]
 }
 
 @test "copyright has matching holder but wrong year: exits non-zero" {
@@ -114,8 +115,8 @@ teardown() {
     echo "# Copyright 2020 Alice" >old-year-holder.txt
     git add old-year-holder.txt
     run bash "${SCRIPT}"
-    [ "$status" -ne 0 ]
-    [[ "$output" == *"Error"* ]]
+    [[ "${status}" -ne 0 ]]
+    [[ "${output}" == *"Error"* ]]
 }
 
 # ---------------------------------------------------------------------------
@@ -126,7 +127,7 @@ teardown() {
     echo "# Copyright 2020 Someone" >unstaged.txt
     # deliberately NOT staged — git diff-index won't list it
     run bash "${SCRIPT}"
-    [ "$status" -eq 0 ]
+    [[ "${status}" -eq 0 ]]
 }
 
 @test "staged deleted file (no longer on disk) is skipped gracefully" {
@@ -137,7 +138,7 @@ teardown() {
     # File is staged for deletion and does not exist on disk;
     # test_file() should return early without error.
     run bash "${SCRIPT}"
-    [ "$status" -eq 0 ]
+    [[ "${status}" -eq 0 ]]
 }
 
 @test "multiple staged files: only the outdated one triggers failure" {
@@ -146,5 +147,5 @@ teardown() {
     echo "# Copyright 2019 Someone" >old.txt
     git add current.txt no-cr.txt old.txt
     run bash "${SCRIPT}"
-    [ "$status" -ne 0 ]
+    [[ "${status}" -ne 0 ]]
 }

--- a/tests/bats/op.bats
+++ b/tests/bats/op.bats
@@ -1,20 +1,21 @@
 #!/usr/bin/env bats
 # Tests for bin/op — the fake 1Password CLI stub used in CI.
 
+# shellcheck disable=SC2154  # BATS_TEST_DIRNAME is set by the BATS runner
 SCRIPT="${BATS_TEST_DIRNAME}/../../bin/op"
 
 @test "op exits successfully" {
     run bash "${SCRIPT}"
-    [ "$status" -eq 0 ]
+    [[ "${status}" -eq 0 ]]
 }
 
 @test "op outputs 'default-value'" {
     run bash "${SCRIPT}"
-    [ "$output" = "default-value" ]
+    [[ "${output}" = "default-value" ]]
 }
 
 @test "op ignores extra arguments" {
     run bash "${SCRIPT}" read "op://vault/item/field"
-    [ "$status" -eq 0 ]
-    [ "$output" = "default-value" ]
+    [[ "${status}" -eq 0 ]]
+    [[ "${output}" = "default-value" ]]
 }

--- a/tests/bats/update-lychee-rev.bats
+++ b/tests/bats/update-lychee-rev.bats
@@ -6,6 +6,7 @@
 # The script references CONFIG=".pre-commit-config.yaml" relative to CWD,
 # so each test cd's into a temporary working directory.
 
+# shellcheck disable=SC2154  # BATS_TEST_DIRNAME is set by the BATS runner
 SCRIPT="${BATS_TEST_DIRNAME}/../../chezmoi/dot_local/bin/executable_update-lychee-rev"
 
 setup() {
@@ -56,7 +57,7 @@ _typical_tags() {
     _stub_git ""
     touch .pre-commit-config.yaml
     run bash "${SCRIPT}" 2>&1
-    [ "$status" -ne 0 ]
+    [[ "${status}" -ne 0 ]]
 }
 
 # ---------------------------------------------------------------------------
@@ -64,21 +65,25 @@ _typical_tags() {
 # ---------------------------------------------------------------------------
 
 @test "replaces 'rev: nightly' with the latest tag and exits 0" {
-    _stub_git "$(_typical_tags)"
+    local tags
+    tags=$(_typical_tags)
+    _stub_git "${tags}"
     printf 'rev: nightly\n' >.pre-commit-config.yaml
     run bash "${SCRIPT}"
-    [ "$status" -eq 0 ]
+    [[ "${status}" -eq 0 ]]
     grep -q 'rev: v0.14.0' .pre-commit-config.yaml
-    ! grep -q 'rev: nightly' .pre-commit-config.yaml
+    run ! grep -q 'rev: nightly' .pre-commit-config.yaml
 }
 
 @test "stdout reports the version and the substitution when updated" {
-    _stub_git "$(_typical_tags)"
+    local tags
+    tags=$(_typical_tags)
+    _stub_git "${tags}"
     printf 'rev: nightly\n' >.pre-commit-config.yaml
     run bash "${SCRIPT}"
-    [ "$status" -eq 0 ]
-    [[ "$output" == *"Latest lychee version: v0.14.0"* ]]
-    [[ "$output" == *"Updated .pre-commit-config.yaml"* ]]
+    [[ "${status}" -eq 0 ]]
+    [[ "${output}" == *"Latest lychee version: v0.14.0"* ]]
+    [[ "${output}" == *"Updated .pre-commit-config.yaml"* ]]
 }
 
 # ---------------------------------------------------------------------------
@@ -86,11 +91,13 @@ _typical_tags() {
 # ---------------------------------------------------------------------------
 
 @test "exits 0 with 'nothing to update' when config lacks rev: nightly" {
-    _stub_git "$(_typical_tags)"
+    local tags
+    tags=$(_typical_tags)
+    _stub_git "${tags}"
     printf 'rev: v0.14.0\n' >.pre-commit-config.yaml
     run bash "${SCRIPT}"
-    [ "$status" -eq 0 ]
-    [[ "$output" == *"nothing to update"* ]]
+    [[ "${status}" -eq 0 ]]
+    [[ "${output}" == *"nothing to update"* ]]
 }
 
 # ---------------------------------------------------------------------------
@@ -101,15 +108,17 @@ _typical_tags() {
     _stub_git "$(printf 'a\trefs/tags/v0.14.0\nb\trefs/tags/v0.10.2\nc\trefs/tags/v0.9.0\n')"
     printf 'rev: nightly\n' >.pre-commit-config.yaml
     run bash "${SCRIPT}"
-    [ "$status" -eq 0 ]
-    [[ "$output" == *"v0.14.0"* ]]
+    [[ "${status}" -eq 0 ]]
+    [[ "${output}" == *"v0.14.0"* ]]
 }
 
 @test "peeled tag entries (^{}) do not appear in the selected version" {
-    _stub_git "$(_typical_tags)"
+    local tags
+    tags=$(_typical_tags)
+    _stub_git "${tags}"
     printf 'rev: nightly\n' >.pre-commit-config.yaml
     run bash "${SCRIPT}"
-    [ "$status" -eq 0 ]
-    [[ "$output" != *"^{}"* ]]
+    [[ "${status}" -eq 0 ]]
+    [[ "${output}" != *"^{}"* ]]
     grep -q 'rev: v0.14.0' .pre-commit-config.yaml
 }


### PR DESCRIPTION
## Summary

- Add `# shellcheck disable=SC2154` to suppress false positive about `BATS_TEST_DIRNAME` (set by the bats runner, not visible to shellcheck)
- Replace `[ ]` with `[[ ]]` throughout all three test files (SC2292)
- Add braces to all variable references: `$var` → `${var}` (SC2250)
- Extract `$(_typical_tags)` inline calls to local variables in `update-lychee-rev.bats` (SC2312 — avoid masking return values)
- Replace bare `! grep -q ...` with `run ! grep -q ...` in `update-lychee-rev.bats` (SC2314 — bats-specific syntax for asserting failure)

Fixes all shellcheck warnings reported by ShellCheck v0.11.0 on `tests/bats/op.bats`, `tests/bats/copyright-year.bats`, and `tests/bats/update-lychee-rev.bats`.

## Test plan

- [ ] All 54 bats tests pass locally
- [ ] ShellCheck reports no issues on the modified files
- [ ] pre-commit.ci passes (shfmt, editorconfig, shellcheck)

https://claude.ai/code/session_01LNTjYKz5HnwaKFKMYgpeuS

---
_Generated by [Claude Code](https://claude.ai/code/session_01LNTjYKz5HnwaKFKMYgpeuS)_