### PR TITLE
ci: prepend keg-only bash 5.x to PATH on macOS

### DIFF
--- a/.github/workflows/test-dotfiles.yml
+++ b/.github/workflows/test-dotfiles.yml
@@ -40,7 +40,9 @@ jobs:
       - name: Install bats-core
         run: |
           if [ "${{ matrix.os }}" = "macos-latest" ]; then
-            brew upgrade bash bats-core 2>/dev/null || brew install bash bats-core
+            brew install bash bats-core 2>/dev/null || brew upgrade bash bats-core
+            # bash is keg-only on macOS; prepend its bin so subsequent steps use bash 5.x
+            echo "$(brew --prefix bash)/bin" >> "${GITHUB_PATH}"
           else
             sudo apt-get update && sudo apt-get install -y bats
           fi


### PR DESCRIPTION
## Summary

- `brew install bash` on macOS is keg-only: bash 5.x lands in `/opt/homebrew/Cellar/bash/.../bin` but is **not** symlinked onto PATH
- Subsequent steps (including `bats tests/bats/`) were still invoking `/bin/bash` 3.2, causing test failures
- Appending `$(brew --prefix bash)/bin` to `$GITHUB_PATH` makes bash 5.x the default for all following steps

## Test plan

- [ ] CI on this PR should complete the bats step successfully (54 tests pass)
- [ ] Chezmoi steps continue with `continue-on-error: true` so they don't block the job

https://claude.ai/code/session_01LNTjYKz5HnwaKFKMYgpeuS

---
_Generated by [Claude Code](https://claude.ai/code/session_01LNTjYKz5HnwaKFKMYgpeuS)_